### PR TITLE
Save params directly instead from the request

### DIFF
--- a/lib/Voxa-Chatbase.js
+++ b/lib/Voxa-Chatbase.js
@@ -55,13 +55,8 @@ async function track(request, reply, transition, isSessionEndedRequest) {
 function createUserMessage(messageSet, request) {
   const unhandledIntents = ['FallbackIntent', 'Unhandled', 'DefaultFallbackIntent'];
   const intentName = request.intent.name || request.request.type;
-  const params = {};
 
-  _.each(request.intent.params, (x) => {
-    params[x.name] = x.value;
-  });
-
-  const userMessage = request.intent.params ? JSON.stringify(params) : '';
+  const userMessage = request.intent.params ? JSON.stringify(request.intent.params) : '';
 
   const newMessage = createMessage(messageSet, request);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxa-chatbase",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Integrate Chatbase analytics into your voice apps using the voxa framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When the changes to support Voxa 3 was made, the piece of code to save the values of the slots changed the `slots` attribute from the `intent` in the request to use the `params` attribute.

Just like the [docs](https://voxa.readthedocs.io/en/master/voxa-event.html#VoxaEvent.intent.params) says, the `slots` object saved the values in an array with objects having a `name` and a `value` attribute. the `params` object doesn't hold that data structure, but it holds the data in a more direct way (again check the docs). So the piece of code I removed was unuseful, and the best way it's to save the `params` object directly. 