### PR TITLE
Save params directly instead from the request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 sudo: required
 node_js:
   - "8.10"
+cache: yarn
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 sudo: required
 node_js:
   - "8.10"
-cache: yarn
+cache:
+  npm: false
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxa-chatbase",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Integrate Chatbase analytics into your voice apps using the voxa framework",
   "main": "lib/Voxa-Chatbase.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxa-chatbase",
-  "version": "0.2.0",
+  "version": "1.0.1",
   "description": "Integrate Chatbase analytics into your voice apps using the voxa framework",
   "main": "lib/Voxa-Chatbase.js",
   "scripts": {

--- a/src/Voxa-Chatbase.ts
+++ b/src/Voxa-Chatbase.ts
@@ -89,8 +89,9 @@ async function track(
 function createUserMessage(messageSet: any, voxaEvent: VoxaEvent) {
   const unhandledIntents = ["FallbackIntent", "Unhandled", "DefaultFallbackIntent"];
   const intentName = _.get(voxaEvent, "intent.name") || voxaEvent.request.type;
+  const params = _.get(voxaEvent, "intent.params");
 
-  const userMessage = _.get(voxaEvent, "intent.params") ? JSON.stringify(voxaEvent.intent.params) : "";
+  const userMessage = params ? JSON.stringify(params) : "";
 
   const newMessage = createMessage(messageSet, voxaEvent);
 

--- a/src/Voxa-Chatbase.ts
+++ b/src/Voxa-Chatbase.ts
@@ -89,13 +89,8 @@ async function track(
 function createUserMessage(messageSet: any, voxaEvent: VoxaEvent) {
   const unhandledIntents = ["FallbackIntent", "Unhandled", "DefaultFallbackIntent"];
   const intentName = _.get(voxaEvent, "intent.name") || voxaEvent.request.type;
-  const params: any = {};
 
-  _.each(_.get(voxaEvent, "intent.params"), (x) => {
-    params[x.name] = x.value;
-  });
-
-  const userMessage = _.get(voxaEvent, "intent.params") ? JSON.stringify(params) : "";
+  const userMessage = _.get(voxaEvent, "intent.params") ? JSON.stringify(voxaEvent.intent.params) : "";
 
   const newMessage = createMessage(messageSet, voxaEvent);
 


### PR DESCRIPTION
When the changes to support Voxa 3 was made, the piece of code to save the values of the slots changed the `slots` attribute from the `intent` in the request to use the `params` attribute.

Just like the [docs](https://voxa.readthedocs.io/en/master/voxa-event.html#VoxaEvent.intent.params) says, the `slots` object saved the values in an array with objects having a `name` and a `value` attribute. the `params` object doesn't hold that data structure, but it holds the data in a more direct way (again check the docs). So the piece of code I removed was unuseful, and the best way it's to save the `params` object directly. 